### PR TITLE
Minor fix

### DIFF
--- a/gtmetrix/interface.py
+++ b/gtmetrix/interface.py
@@ -18,10 +18,11 @@ class _TestObject(object):
     STATE_COMPLETED = 'completed'
     STATE_ERROR = 'error'
 
-    def __init__(self, auth, test_id, poll_state_url=None):
+    def __init__(self, auth, test_id, poll_state_url=None, credits_left=None):
         self.poll_state_url = (poll_state_url or
                                os.path.join(settings.GTMETRIX_REST_API_URL, test_id))
         self.test_id = test_id
+        self.credits_left = credits_left
         self.state = self.STATE_QUEUED
         self.auth = auth
         self.results = {}


### PR DESCRIPTION
GTMetrix is now returning `credits_left` along with `test_id` and `poll_state_url` in POST /api/0.1/test response.