### PR TITLE
Allow "plus" in email address

### DIFF
--- a/gtmetrix/utils.py
+++ b/gtmetrix/utils.py
@@ -112,7 +112,7 @@ YSLOW_RULES = {
 
 # Snagged from: https://www.scottbrady91.com/Email-Verification/Python-Email-Verification-Script
 email_re = re.compile(
-    '^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(''\.[a-z]{2,''4})$')
+    '^[_a-z0-9+-]+(\.[_a-z0-9+-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(''\.[a-z]{2,''4})$')
 
 
 def validate_email(email):


### PR DESCRIPTION
so you could use email like `username+tag@example.com` (gtmetrix themselves allow this)