### PR TITLE
Decrease poll interval when waiting for test to complete

### DIFF
--- a/gtmetrix/interface.py
+++ b/gtmetrix/interface.py
@@ -82,7 +82,7 @@ class _TestObject(object):
         number_executions = 0
         while not self.state == self.STATE_COMPLETED and (number_executions < 30):
             number_executions += 1
-            time.sleep(30)
+            time.sleep(3)
             response_data = self._request(self.poll_state_url)
             self.state = response_data['state']
 


### PR DESCRIPTION
30 seconds sounds a bit too much. According to [docs][1],
> The recommended poll interval is 1 second.

[1]: https://gtmetrix.com/api/docs/0.1/#api-test-state